### PR TITLE
Add thinking mode setting to Ollama translator

### DIFF
--- a/src/main/kotlin/net/gtransagent/translator/OllamaTranslator.kt
+++ b/src/main/kotlin/net/gtransagent/translator/OllamaTranslator.kt
@@ -58,6 +58,11 @@ class OllamaTranslator : SingleInputTranslator() {
      */
     private var enableContext: Boolean = true
 
+    /**
+     * Whether to enable thinking mode in models that support it.
+     */
+    private var enableThinking: Boolean = false
+
     private var engineAndModelMap: MutableMap<String, String> = mutableMapOf()
     private var supportedEngines: MutableList<PublicConfig.TranslateEngine> = mutableListOf()
 
@@ -95,6 +100,7 @@ class OllamaTranslator : SingleInputTranslator() {
 
         mConcurrent = (configs["concurrent"] as Int?) ?: 1
         enableContext = (configs["enableContext"] as Boolean?) ?: true
+        enableThinking = (configs["enableThinking"] as Boolean?) ?: false
         systemPrompts = ((configs["systemPrompts"] as String?) ?: DEFAULT_SYSTEM_PROMPTS).trim()
         userPrompts = ((configs["userPrompts"] as String?) ?: DEFAULT_USER_PROMPTS).trim()
 
@@ -348,6 +354,7 @@ class OllamaTranslator : SingleInputTranslator() {
             jsonMap["model"] = engineAndModelMap[engineCode]!!
             jsonMap["stream"] = false
             jsonMap["keep_alive"] = "30m"
+            jsonMap["think"] = enableThinking
 
             val payload = disableHtmlEscapingGson.toJson(jsonMap)
 

--- a/src/main/resources/editable/translator/Ollama.yaml
+++ b/src/main/resources/editable/translator/Ollama.yaml
@@ -28,6 +28,9 @@ engineMapping:
 
 concurrent: 3  # Number of concurrent requests
 
+# Whether to enable thinking mode in models that support it.
+enableThinking: false
+
 # Whether to pass surrounding input items as context during translation.
 # When enabled, previous and next items in the same batch are included as context
 # to help the LLM maintain translation consistency.


### PR DESCRIPTION
This adds a setting to allow you to disable thinking mode to improve translation speed when using Ollama with models that support it.